### PR TITLE
🚑 Fix: #15 [버그] 비밀번호 입력 창 Focus 시 윈도우에서만 default UI 나옴

### DIFF
--- a/src/components/InputBox/InputBox.style.tsx
+++ b/src/components/InputBox/InputBox.style.tsx
@@ -27,7 +27,10 @@ export const InputBox = styled.input<{ isFocused: boolean }>`
   padding-left: 5px;
   padding-top: ${({ isFocused }) => (isFocused ? "12px" : "0px")};
   background-color: ${COLOR.BackgroundColor};
-
+  &::-ms-reveal,
+  &::-webkit-reveal {
+    display: none;
+  }
   &:focus {
     border: 1px solid ${COLOR.Gray2};
   }


### PR DESCRIPTION
InputBox.style.tsx - InputBox
&::-ms-reveal,
&::-webkit-reveal {
    display: none;
}
적용

Closed #15